### PR TITLE
Preserve parameter order for pack_run

### DIFF
--- a/neo4j/src/bolt.rs
+++ b/neo4j/src/bolt.rs
@@ -129,7 +129,7 @@ impl BoltStream {
 
     /// Pack a RUN message.
     ///
-    pub fn pack_run(&mut self, statement: &str, parameters: HashMap<&str, Value>) {
+    pub fn pack_run(&mut self, statement: &str, parameters: Vec<(&str, Value)>) {
         debug!("C: RUN {:?} {:?}", statement, parameters);
         self.packer.pack_structure_header(2, 0x10);
         self.packer.pack_string(statement);
@@ -275,7 +275,7 @@ impl BoltStream {
                         _ => match fields.remove(0) {
                             Value::Dictionary(metadata) => {
                                 debug!("S: SUCCESS({:?})", metadata);
-                                response.summary = Some(BoltSummary::Success(metadata));
+                                response.summary = Some(BoltSummary::Success(metadata.into_iter().collect()));
                             },
                             _ => panic!("Non-map metadata"),
                         },
@@ -291,7 +291,7 @@ impl BoltStream {
                         _ => match fields.remove(0) {
                             Value::Dictionary(metadata) => {
                                 debug!("S: IGNORED({:?})", metadata);
-                                response.summary = Some(BoltSummary::Ignored(metadata));
+                                response.summary = Some(BoltSummary::Ignored(metadata.into_iter().collect()));
                             },
                             _ => panic!("Non-map metadata"),
                         },
@@ -307,7 +307,7 @@ impl BoltStream {
                         _ => match fields.remove(0) {
                             Value::Dictionary(metadata) => {
                                 debug!("S: FAILURE({:?})", metadata);
-                                response.summary = Some(BoltSummary::Failure(metadata));
+                                response.summary = Some(BoltSummary::Failure(metadata.into_iter().collect()));
                             },
                             _ => panic!("Non-map metadata"),
                         },

--- a/neo4j/src/cypher.rs
+++ b/neo4j/src/cypher.rs
@@ -118,7 +118,7 @@ impl CypherStream {
         self.bolt.compact_responses();
     }
 
-    pub fn run(&mut self, statement: &str, parameters: HashMap<&str, Value>) -> StatementResult {
+    pub fn run(&mut self, statement: &str, parameters: Vec<(&str, Value)>) -> StatementResult {
         self.bolt.pack_run(statement, parameters);
         self.bolt.pack_pull_all();
         let head = self.bolt.collect_response();

--- a/packstream/src/values.rs
+++ b/packstream/src/values.rs
@@ -244,20 +244,17 @@ impl fmt::Display for Data {
 macro_rules! parameters(
     {} => {
         {
-            use std::collections::HashMap;
-
-            HashMap::new()
+            Vec::new()
         }
     };
 
     { $($key:expr => $value:expr),* } => {
         {
-            use std::collections::HashMap;
             use $crate::values::{Value, ValueCast};
 
-            let mut map : HashMap<&str, Value> = HashMap::new();
+            let mut map : Vec<(&str, Value)> = Vec::new();
             $(
-                map.insert($key, ValueCast::from(&$value));
+                map.push(($key, ValueCast::from(&$value)));
             )+;
 
             map

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ impl log::Log for SimpleLogger {
 //////////////////////////////////////////////////////////////////////
 
 use std::env;
-use std::collections::{VecDeque, HashMap};
+use std::collections::VecDeque;
 
 extern crate neo4j;
 use neo4j::cypher::{CypherStream};
@@ -50,7 +50,7 @@ fn main() {
 
 }
 
-fn dump(mut cypher: CypherStream, statement: &str, parameters: HashMap<&str, Value>) {
+fn dump(mut cypher: CypherStream, statement: &str, parameters: Vec<(&str, Value)>) {
     // begin transaction
 //    cypher.begin_transaction(None);
 


### PR DESCRIPTION
Since parameters in Cypher are addressed by either index or name, don't reorder them into a HashMap before shipping off to the server.